### PR TITLE
#14 STFTによる音声データの振幅スペクトログラム変換とMNFによる分解

### DIFF
--- a/NMF.m
+++ b/NMF.m
@@ -13,7 +13,7 @@ function [W, H] = NMF(X,K,args)
 %
 
 arguments
-    X (:,:) double {mustBeReal, mustBePositive}
+    X (:,:) double {mustBeReal, mustBeNonnegative}
     K (1,1) double {mustBePositive, mustBeInteger}
     args.nItr (1,1) double {mustBePositive, mustBeInteger} = 1000
     args.typeCostFunction string {mustBeMember(args.typeCostFunction, ["EU","KL","IS"])} = "EU"

--- a/main.m
+++ b/main.m
@@ -1,13 +1,13 @@
 clear; close all; clc;
 
 % 基底
-K = 10;
+K = 2;
 
 % 音声ファイル
-audiofile = "kitamuravoice.wav";
+audiofile = "sound.wav";
 
 % 音声ファイルの振幅スペクトログラム変換(非負観測行列)
-X = STFT(audiofile);
+[X, fs] = STFT(audiofile);
 Nyquist = fix(size(X,1)/2) + 1;
 X = X(1:Nyquist,:);
 
@@ -18,12 +18,40 @@ X = X(1:Nyquist,:);
 nItr = 1000; % 更新式の反復回数
 
 % Xの表示
-figure; imagesc(X);
+yGrid = linspace(0, fs/2, Nyquist);
+xGrid = linspace(0, ((I+1)*J)/(fs), J);
+colorlim = [0, 80];
+ylimit = [0, 5000];
+
+figure; imagesc(xGrid, yGrid, X);
+axis xy;
+fontsize(gca, 12, "pixels");
+ylabel("周波数 [Hz]");
+xlabel("時間 [s]");
+caxis(colorlim);
+ylim(ylimit);
+colorbar;
 
 [W, H] = NMF(X, K, "convergenceCurve",true,"nItr",nItr,"typeCostFunction","EU");
 
-%imagesc(W_EU,H_EU);
-% 近似された観測行列の表示
-Xhat = W*H;
-figure; imagesc(Xhat);
+
+% 分解音の表示
+Y=W(:,1)*H(1,:);
+figure; imagesc(xGrid, yGrid, W(:,1)*H(1,:));
+axis xy;
+fontsize(gca, 12, "pixels");
+ylabel("周波数 [Hz]");
+xlabel("時間 [s]");
+caxis(colorlim);
+ylim(ylimit);
+colorbar;
+
+figure; imagesc(xGrid, yGrid, W(:,2)*H(2,:));
+axis xy;
+fontsize(gca, 12, "pixels");
+ylabel("周波数 [Hz]");
+xlabel("時間 [s]");
+caxis(colorlim);
+ylim(ylimit);
+colorbar;
 

--- a/main.m
+++ b/main.m
@@ -1,23 +1,29 @@
 clear; close all; clc;
 
-% 行列のサイズ
-I = 100; % Xの行数
-J = 100; % Xの列数
-K = 10; % 基底数
+% 基底
+K = 10;
+
+% 音声ファイル
+audiofile = "kitamuravoice.wav";
+
+% 音声ファイルの振幅スペクトログラム変換(非負観測行列)
+X = STFT(audiofile);
+Nyquist = fix(size(X,1)/2) + 1;
+X = X(1:Nyquist,:);
+
+% 行列サイズの取得
+[I, J] = size(X);
 
 % パラメータ
 nItr = 1000; % 更新式の反復回数
 
-% 非負観測行列の生成
-trueW = rand(I, K); % 非負乱数（開区間(0, 1)）
-trueH = rand(K, J); % 非負乱数（開区間(0, 1)）
-X = trueW * trueH; % ランクKの非負観測行列
-
 % Xの表示
 figure; imagesc(X);
 
-[W_EU, H_EU] = NMF(X, K, "convergenceCurve",true,"nItr",nItr,"typeCostFunction","EU");
+[W, H] = NMF(X, K, "convergenceCurve",true,"nItr",nItr,"typeCostFunction","EU");
 
+%imagesc(W_EU,H_EU);
 % 近似された観測行列の表示
-Xhat_EU = W_EU*H_EU;
-figure; imagesc(Xhat_EU);
+Xhat = W*H;
+figure; imagesc(Xhat);
+

--- a/main.m
+++ b/main.m
@@ -7,9 +7,9 @@ K = 2;
 audiofile = "sound.wav";
 
 % 音声ファイルの振幅スペクトログラム変換(非負観測行列)
-[X, fs] = STFT(audiofile);
-Nyquist = fix(size(X,1)/2) + 1;
-X = X(1:Nyquist,:);
+[X, fs] = STFT(audiofile, "fftSize", 2048);
+Nyquist = fix(size(X,1)/2) + 1; % ナイキスト周波数にあたるデータ位置
+X = X(1:Nyquist,:); % ナイキスト周波数までを抽出
 
 % 行列サイズの取得
 [I, J] = size(X);
@@ -17,26 +17,18 @@ X = X(1:Nyquist,:);
 % パラメータ
 nItr = 1000; % 更新式の反復回数
 
-% Xの表示
-yGrid = linspace(0, fs/2, Nyquist);
-xGrid = linspace(0, ((I+1)*J)/(fs), J);
-colorlim = [0, 80];
-ylimit = [0, 5000];
-
-figure; imagesc(xGrid, yGrid, X);
-axis xy;
-fontsize(gca, 12, "pixels");
-ylabel("周波数 [Hz]");
-xlabel("時間 [s]");
-caxis(colorlim);
-ylim(ylimit);
-colorbar;
-
-[W, H] = NMF(X, K, "convergenceCurve",true,"nItr",nItr,"typeCostFunction","EU");
-
+[W, H] = NMF(X, K, "convergenceCurve",true,"nItr",nItr,"typeCostFunction","KL");
 
 % 分解音の表示
-Y=W(:,1)*H(1,:);
+% 縦軸を0からナイキスト周波数までI個に分割
+yGrid = linspace(0, fs/2, I);
+% numRow=(signalLength - fftSize)/shiftSize+1
+% numRow=J,fftSize=2*shiftSize=I
+% 再生時間=signalLength/fs, 以上から再生時間算出
+% 横軸として再生時間をJ個に分割
+xGrid = linspace(0, ((I+1)*J)/(fs), J);
+colorlim = [0, 80];
+ylimit = [0, 10000];
 figure; imagesc(xGrid, yGrid, W(:,1)*H(1,:));
 axis xy;
 fontsize(gca, 12, "pixels");

--- a/stft.m
+++ b/stft.m
@@ -1,0 +1,73 @@
+%myvoiceの読み込み
+[y, fs] = audioread("myvoice.wav");
+y = ( y(:, 1) + y(:, 2) ) / 2;
+
+%信号長取得
+signalLength = size(y, 1);
+
+%fftSize定義
+fftSize = 1024;
+
+%shiftSize定義
+shiftSize = fftSize / 2;
+
+%ハン窓作成
+window = hann(fftSize);
+
+%行サイズ計算
+numRow = ceil((signalLength - fftSize) / shiftSize) + 1;
+
+%paddingSize計算
+paddingSize = fftSize - 1;
+
+%zeros生成
+padding = zeros(paddingSize, 1);
+
+%padding結合
+yPadding = [y;padding];
+
+%spec定義
+spec = zeros(fftSize, numRow);
+ 
+for n = 1:numRow
+    %yから抽出
+    vec = yPadding(1 + (n - 1)*shiftSize:fftSize + (n - 1)*shiftSize,1);
+
+    %ハン窓乗算
+    vecWindow = vec .* window;
+
+    %fft
+    yDft = fft(vecWindow);
+
+    %結果格納
+    spec(:, n) = yDft;
+end
+
+%---パワースペクトログラムの表示部---
+
+%絶対値の計算
+ampSpec = sqrt(real(spec).^2 + imag(spec).^2);
+%specAbs = abs(spec);
+
+%db変換
+powerSpec = 20 * log10(ampSpec);
+
+%縦軸生成(周波数[Hz])
+%fsのfftsize分割
+yGrid = linspace(0,fs,fftSize);
+
+%横軸生成(時間[s])
+%1秒のデータ数=fs個
+%全体の時間=signalLength/fs
+xGrid = linspace(0, signalLength / fs, numRow);
+
+%スペクトログラム描画
+imagesc(xGrid, yGrid, powerSpec);
+axis xy;
+fontsize(gca, 15, "pixels")
+ylabel("周波数 [Hz]", 'FontSize', 18);
+xlabel("時間 [s]", 'FontSize', 18);
+caxis([-60 30]);
+ylim([0 fs/2]);
+colorbar;
+

--- a/stft.m
+++ b/stft.m
@@ -85,7 +85,7 @@ fontsize(gca, 15, "pixels");
 ylabel("周波数 [Hz]", 'FontSize', 18);
 xlabel("時間 [s]", 'FontSize', 18);
 caxis([0 80]);
-ylim([0 5000]);
+ylim([0 10000]);
 colorbar;
 
 end

--- a/stft.m
+++ b/stft.m
@@ -1,12 +1,25 @@
-%myvoiceの読み込み
-[y, fs] = audioread("myvoice.wav");
-y = ( y(:, 1) + y(:, 2) ) / 2;
+function [X] = STFT(filename, args)
+% STFT: 入力ファイルのSTFTを出力
+%   [Input]
+%       filename: 音声データのファイル名
+%       fftSize: fftの範囲
+%   [OutPut]
+%       X: 2次元実数非負観測行列
+%
+arguments
+    filename string
+    args.fftSize (1,1) double {mustBePositive, mustBeInteger} = 1024
+end
 
+fftSize = args.fftSize;
+
+%ファイルの読み込み
+[y, fs] = audioread(filename);
+if(size(y,2) == 2)
+    y = ( y(:, 1) + y(:, 2) ) / 2;
+end
 %信号長取得
 signalLength = size(y, 1);
-
-%fftSize定義
-fftSize = 1024;
 
 %shiftSize定義
 shiftSize = fftSize / 2;
@@ -52,6 +65,8 @@ ampSpec = sqrt(real(spec).^2 + imag(spec).^2);
 %db変換
 powerSpec = 20 * log10(ampSpec);
 
+X = powerSpec;
+
 %縦軸生成(周波数[Hz])
 %fsのfftsize分割
 yGrid = linspace(0,fs,fftSize);
@@ -67,7 +82,8 @@ axis xy;
 fontsize(gca, 15, "pixels")
 ylabel("周波数 [Hz]", 'FontSize', 18);
 xlabel("時間 [s]", 'FontSize', 18);
-caxis([-60 30]);
+caxis([-30 20]);
 ylim([0 fs/2]);
 colorbar;
 
+end

--- a/stft.m
+++ b/stft.m
@@ -1,10 +1,12 @@
-function [X] = STFT(filename, args)
+function [X,fs] = STFT(filename, args)
 % STFT: 入力ファイルのSTFTを出力
 %   [Input]
 %       filename: 音声データのファイル名
 %       fftSize: fftの範囲
+%       samplingRate: サンプリング周波数
 %   [OutPut]
 %       X: 2次元実数非負観測行列
+%       fs: サンプリング周波数
 %
 arguments
     filename string
@@ -57,15 +59,15 @@ for n = 1:numRow
 end
 
 %---パワースペクトログラムの表示部---
-
 %絶対値の計算
 ampSpec = sqrt(real(spec).^2 + imag(spec).^2);
 %specAbs = abs(spec);
 
-%db変換
-powerSpec = 20 * log10(ampSpec);
+X = ampSpec;
 
-X = powerSpec;
+%db変換
+%powerSpec = 20 * log10(ampSpec);
+powerSpec = ampSpec;
 
 %縦軸生成(周波数[Hz])
 %fsのfftsize分割
@@ -79,11 +81,11 @@ xGrid = linspace(0, signalLength / fs, numRow);
 %スペクトログラム描画
 imagesc(xGrid, yGrid, powerSpec);
 axis xy;
-fontsize(gca, 15, "pixels")
+fontsize(gca, 15, "pixels");
 ylabel("周波数 [Hz]", 'FontSize', 18);
 xlabel("時間 [s]", 'FontSize', 18);
-caxis([-30 20]);
-ylim([0 fs/2]);
+caxis([0 80]);
+ylim([0 5000]);
 colorbar;
 
 end


### PR DESCRIPTION
ひとまずSTFTを関数化してSTFTの時に使ったKitamuravoiceを入れてざっくり動くところまでやってます。

mainに音声データ入力
STFT関数を呼び出してデータを振幅変換
振幅データをMNFの観測行列として入力
NMFの近似結果を表示